### PR TITLE
Do not import procedural macros from gstd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,6 @@
 #![no_std]
 
-#[allow(unused_imports)]
-#[macro_use]
 pub extern crate gstd;
-
 pub use functions::*;
 
 mod common;


### PR DESCRIPTION
As I found out, the following expression is enough for `#[gstd::async_main]` to work: (also I tested it on dapps-sharded-fungible-token)
```rust
use gstd_fluent::{
    self as builder,
    gstd::{self, exec, msg, prelude::*, ActorId},
    //     ^^^^
};
```